### PR TITLE
Andrew Grimm: Japanese - a programmer's language

### DIFF
--- a/andrew_grimm-Japanese_a_programmers_language/README.md
+++ b/andrew_grimm-Japanese_a_programmers_language/README.md
@@ -1,0 +1,28 @@
+# Japanese - a programmer's language
+
+At first glance, Japanese looks to westerners like a very strange and difficult language. However, in many ways it is more similar to English than other European languages are, and an increasing amount of its vocabulary comes from English. In addition, so far I have found Japanese to be a very logical language.
+
+While half an hour is not sufficient to teach the entirety of the Japanese language, I intend to show a glimpse of what Japanese is like, and some of its interesting idiosyncrasies. This will include "English made in Japan" (wasei-eigo), honorifics such as the "san" in "Daniel-san", and why both toilets and temples get the same "o" prefix (bikago).
+
+- Preferred presentation day: no preference
+- Presentation language: English.
+
+## Andrew Grimm
+## アンドリュー グリム
+
+## University of New South Wales.
+## ニューサウスウェールズ大学 (UNSW)
+
+Andrew Grimm is a bioinformatician at the University of New South Wales in Sydney, Australia. He came across Ruby while using Rails at his previous job associated with the Encyclopedia of Life, but now specialises in Plain Old Ruby Objects.
+
+He has worked on various projects outside of work. One analyzed why you always end up at "Philosophy" in Wikipedia. Another was a fork of Heckle in which zombies eat your brains unless your unit tests can kill them all. At RubyKaigi 2011 he demonstrated the Small Eigen Collider, which generates random Ruby code that can be run under different implementations of Ruby to check for inconsistencies or bugs.
+
+He started learning Japanese in order cope with Tokyo for RubyKaigi 2011, expecting to quit a few weeks after starting the course. He has forgotten to give up.
+
+バイオインフォマティクスの科学者
+
+- [My website](https://andrewjgrimm.wordpress.com/)
+- [My twitter](https://twitter.com/#!/andrewjgrimm)
+- [Past talk slides](http://www.slideshare.net/agrimm)
+- [Past talk videos](https://vimeo.com/channels/332579)
+- [Past t-shirt](http://www.zazzle.com/small_eigen_collider_japanese_and_english_text_tshirt-235235813665782515)

--- a/andrew_grimm-Japanese_a_programmers_language/README.md
+++ b/andrew_grimm-Japanese_a_programmers_language/README.md
@@ -17,7 +17,7 @@ Andrew Grimm is a bioinformatician at the University of New South Wales in Sydne
 
 He has worked on various projects outside of work. One analyzed why you always end up at "Philosophy" in Wikipedia. Another was a fork of Heckle in which zombies eat your brains unless your unit tests can kill them all. At RubyKaigi 2011 he demonstrated the Small Eigen Collider, which generates random Ruby code that can be run under different implementations of Ruby to check for inconsistencies or bugs.
 
-He started learning Japanese in order cope with Tokyo for RubyKaigi 2011, expecting to quit a few weeks after starting the course. He has forgotten to give up.
+He started learning Japanese in order to cope with Tokyo for RubyKaigi 2011, expecting to quit a few weeks after starting the course. He forgot to give up.
 
 バイオインフォマティクスの科学者
 


### PR DESCRIPTION
At first glance, Japanese looks to westerners like a very strange and difficult language. However, in many ways it is more similar to English than other European languages are, and an increasing amount of its vocabulary comes from English. In addition, so far I have found Japanese to be a very logical language.

While half an hour is not sufficient to teach the entirety of the Japanese language, I intend to show a glimpse of what Japanese is like, and some of its interesting idiosyncrasies. This will include "English made in Japan" (wasei-eigo), honorifics such as the "san" in "Daniel-san", and why both toilets and temples get the same "o" prefix (bikago).
